### PR TITLE
Improve support for large matrices

### DIFF
--- a/gimmik/kernels/c-openmp/cstream.mako
+++ b/gimmik/kernels/c-openmp/cstream.mako
@@ -8,8 +8,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* restrict b, ${dtype}* restrict c)
 {
     const int n = ${n};
-    const int ldb = ${ldb};
-    const int ldc = ${ldc};
+    const ${'long long' if k*ldb >= 2**31 else 'int'} ldb = ${ldb};
+    const ${'long long' if m*ldc >= 2**31 else 'int'} ldc = ${ldc};
 % endif
 
     #pragma omp parallel for simd private(dotp)

--- a/gimmik/kernels/c/cstream.mako
+++ b/gimmik/kernels/c/cstream.mako
@@ -8,8 +8,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* restrict b, ${dtype}* restrict c)
 {
     const int n = ${n};
-    const int ldb = ${ldb};
-    const int ldc = ${ldc};
+    const ${'long long' if k*ldb >= 2**31 else 'int'} ldb = ${ldb};
+    const ${'long long' if m*ldc >= 2**31 else 'int'} ldc = ${ldc};
 % endif
 
     #pragma omp simd

--- a/gimmik/kernels/cuda/bstream-msplit.mako
+++ b/gimmik/kernels/cuda/bstream-msplit.mako
@@ -20,8 +20,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/cuda/bstream.mako
+++ b/gimmik/kernels/cuda/bstream.mako
@@ -15,8 +15,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/cuda/cstream-ksplit.mako
+++ b/gimmik/kernels/cuda/cstream-ksplit.mako
@@ -21,8 +21,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/cuda/cstream.mako
+++ b/gimmik/kernels/cuda/cstream.mako
@@ -17,8 +17,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
     ${dtype} dotp;

--- a/gimmik/kernels/hip/bstream-msplit.mako
+++ b/gimmik/kernels/hip/bstream-msplit.mako
@@ -20,8 +20,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/hip/bstream.mako
+++ b/gimmik/kernels/hip/bstream.mako
@@ -15,8 +15,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/hip/cstream-ksplit.mako
+++ b/gimmik/kernels/hip/cstream-ksplit.mako
@@ -21,8 +21,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 

--- a/gimmik/kernels/hip/cstream.mako
+++ b/gimmik/kernels/hip/cstream.mako
@@ -17,8 +17,8 @@ ${kname}(int n,
 ${kname}(const ${dtype}* __restrict__ b, ${dtype}* __restrict__ c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
     ${dtype} dotp;

--- a/gimmik/kernels/ispc/cstream.mako
+++ b/gimmik/kernels/ispc/cstream.mako
@@ -8,8 +8,8 @@ ${kname}(uniform int n,
 ${kname}(const uniform ${dtype} b[], ${dtype} uniform c[])
 {
     const uniform int n = ${n};
-    const uniform int ldb = ${ldb};
-    const uniform int ldc = ${ldc};
+    const uniform ${'long long' if k*ldb >= 2**31 else 'int'} ldb = ${ldb};
+    const uniform ${'long long' if m*ldc >= 2**31 else 'int'} ldc = ${ldc};
 % endif
 
     foreach (i = 0 ... n)

--- a/gimmik/kernels/metal/bstream-msplit.mako
+++ b/gimmik/kernels/metal/bstream-msplit.mako
@@ -22,8 +22,8 @@ ${kname}(device const ${dtype}* b, device ${dtype}* c,
          uint2 tpitg [[thread_position_in_threadgroup]])
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = tpig.x;
 

--- a/gimmik/kernels/metal/bstream.mako
+++ b/gimmik/kernels/metal/bstream.mako
@@ -15,8 +15,8 @@ ${kname}(device const ${dtype}* b, device ${dtype}* c,
          uint i [[thread_position_in_grid]])
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
 
     if (i < n)

--- a/gimmik/kernels/metal/cstream-ksplit.mako
+++ b/gimmik/kernels/metal/cstream-ksplit.mako
@@ -23,8 +23,8 @@ ${kname}(device const ${dtype}* b, device ${dtype}* c,
          uint2 tpitg [[thread_position_in_threadgroup]])
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     const int i = tpig.x;
 

--- a/gimmik/kernels/metal/cstream.mako
+++ b/gimmik/kernels/metal/cstream.mako
@@ -17,8 +17,8 @@ ${kname}(device const ${dtype}* b, device ${dtype}* c,
          uint i [[thread_position_in_grid]])
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     ${dtype} dotp;
 

--- a/gimmik/kernels/opencl/bstream-msplit.mako
+++ b/gimmik/kernels/opencl/bstream-msplit.mako
@@ -18,8 +18,8 @@ ${kname}(int n,
 ${kname}(__global const ${dtype}* restrict b, __global ${dtype}* restrict c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = get_global_id(0);
     int lx = get_local_id(0), ly = get_local_id(1);

--- a/gimmik/kernels/opencl/bstream.mako
+++ b/gimmik/kernels/opencl/bstream.mako
@@ -8,8 +8,8 @@ ${kname}(int n,
 ${kname}(__global const ${dtype}* restrict b, __global ${dtype}* restrict c)
 {
     const int n = ${n};
-    const int ldb = ${ldb};
-    const int ldc = ${ldc};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = get_global_id(0);
 

--- a/gimmik/kernels/opencl/cstream-ksplit.mako
+++ b/gimmik/kernels/opencl/cstream-ksplit.mako
@@ -19,8 +19,8 @@ ${kname}(int n,
 ${kname}(__global const ${dtype}* restrict b, __global ${dtype}* restrict c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = get_global_id(0);
     int lx = get_local_id(0), ly = get_local_id(1);

--- a/gimmik/kernels/opencl/cstream.mako
+++ b/gimmik/kernels/opencl/cstream.mako
@@ -13,8 +13,8 @@ ${kname}(int n,
 ${kname}(__global const ${dtype}* restrict b, __global ${dtype}* restrict c)
 {
     const int n = ${-(-n // width)};
-    const int ldb = ${ldb // width};
-    const int ldc = ${ldc // width};
+    const ${'long' if k*ldb >= width*2**31 else 'int'} ldb = ${ldb // width};
+    const ${'long' if m*ldc >= width*2**31 else 'int'} ldc = ${ldc // width};
 % endif
     int i = get_global_id(0);
 


### PR DESCRIPTION
This enables GiMMiK to work on larger matrices by using (as required) larger integers.  There should be no decrease in performance for smaller matrices.